### PR TITLE
Added RingBuf, cleaned up Windows

### DIFF
--- a/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
@@ -82,7 +82,7 @@ object RingBuf {
     RingBuf(Vector.fill(size)(ev.zero), 0)
 
   def monoid[A](size: Int)(implicit ev: Monoid[A]): Monoid[RingBuf[A]] =
-    Monoid.from(RingBuf.empty(size))(_ + _)
+    Monoid.from[RingBuf[A]](RingBuf.empty(size))(_ + _)
 
   implicit def equiv[A: Equiv](implicit ev: Equiv[A]): Equiv[RingBuf[A]] =
     new Equiv[RingBuf[A]] {

--- a/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
@@ -1,47 +1,61 @@
 package com.twitter.algebird
 
+/**
+ * Value class to hold references to indices internal to RingBuf.
+ */
 case class Idx(value: Int) extends AnyVal {
   def +(i: Int): Idx = Idx(value + i)
   def -(i: Int): Idx = Idx(value - i)
+
+  // Look/ itself up in the supplied vector.
+  def of[A](v: Vector[A]): A = v(value)
+
+  // updates the supplied vector with the supplied value.
+  def update[A](v: Vector[A], a: A): Vector[A] = v.updated(value, a)
 }
 
 object Idx {
   def bounded(i: Long, bound: Int): Idx = Idx(((i + bound) % bound).toInt)
 }
 
-case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
+case class RingBuf[A](slots: Vector[A], index: Idx) { lhs =>
   import RingBuf._
+  /**
+   * Slots are 0-indexed from the current `index`, looking backwards.
+   *
+   * `toIdx` converts an index into a vector position in `slots` for
+   * internal use.
+   *
+   * i=1, index=5, toIdx(i)=Idx(4)
+   * i=(slots.size - 1), index=5, toIdx(i)==Idx(6) (ie last item)
+   */
+  private[this] def toIdx(i: Long): Idx = rawIdx(i + index.value)
 
   /**
-   * Slots are 0-indexed from the current index, looking backwards.
-   *
-   * `makeIdx` converts an index into a vector position in `slots`.
-   *
-   * i=1, index=5, makeIdx(i)=Idx(4)
-   * i=(slots.size - 1), index=5, makeIdx(i)==Idx(6) (ie last item)
+   * Use if you don't need the `index.value` offset.
    */
-  private[this] def makeIdx(i: Long): Idx = Idx.bounded(i, slots.size)
+  private[this] def rawIdx(i: Long): Idx = Idx.bounded(i, slots.size)
 
-  // TODO - this assertion is a LITTLE janky, since we want to be able
-  // to bump forward during step.
-  private[this] def toInternal(i: Long): Idx = {
+  private[this] def assertBounds(i: Long): Unit =
     assert(i >= 0 && i < slots.size, s"$i is out of allowed bounds: [0 $slots.size)")
-    makeIdx(i + index)
-  }
 
   /**
    * Returns a copy of the RingBuf with `a` added in to the proper
    * externally-indexed slot.
    */
   def add(a: A, i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
-    val idx = toInternal(i).value
-    copy(slots = slots.updated(idx, ev.plus(slots(idx), a)))
+    assertBounds(i)
+    val idx = toIdx(i)
+    copy(slots = idx.update(slots, ev.plus(idx.of(slots), a)))
   }
 
   /**
    * Look up the item in the vector by external index.
    */
-  def apply(i: Long): A = slots(toInternal(i).value)
+  def apply(i: Long): A = {
+    assertBounds(i)
+    toIdx(i).of(slots)
+  }
 
   /**
    * Steps the RingBuf forward `i` steps, zero-ing out all new
@@ -50,10 +64,10 @@ case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
   def step(i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
     if (i <= 0) this
     else {
-      val v = (1L to (i min slots.size)).foldLeft(slots) { (acc, j) =>
-        acc.updated(makeIdx(j + index).value, ev.zero)
+      val v = (1L to (i min slots.size)).foldLeft(slots) {
+        (acc, j) => toIdx(j).update(acc, ev.zero)
       }
-      RingBuf(v, makeIdx(i + index).value)
+      RingBuf(v, toIdx(i))
     }
   }
 
@@ -62,24 +76,23 @@ case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
       case (l, r) => ev.plus(l, r)
     }
     val newSize = lhs.slots.size min rhs.slots.size
-    RingBuf(merge.toVector.reverse, makeIdx(newSize - 1).value)
+    RingBuf(merge.toVector.reverse, rawIdx(newSize - 1))
   }
 
   // oldest-to-newest iterator across partial sums
   def iterator: Iterator[A] =
-    (1 to slots.size).iterator.map(i => slots(makeIdx(index + i).value))
+    (1 to slots.size).iterator.map(i => toIdx(i).of(slots))
 
   // newest-to-oldest iterator across partial sums
   def reverseIterator: Iterator[A] =
-    (0 until slots.size).iterator.map(i => slots(makeIdx(index - i).value))
+    (0 until slots.size).iterator.map(i => rawIdx(index.value - i).of(slots))
 
   def size: Int = slots.size
-  def length: Int = slots.length
 }
 
 object RingBuf {
   def empty[A](size: Int)(implicit ev: Monoid[A]): RingBuf[A] =
-    RingBuf(Vector.fill(size)(ev.zero), 0)
+    RingBuf(Vector.fill(size)(ev.zero), Idx(0))
 
   def monoid[A](size: Int)(implicit ev: Monoid[A]): Monoid[RingBuf[A]] =
     Monoid.from[RingBuf[A]](RingBuf.empty(size))(_ + _)

--- a/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
@@ -1,24 +1,6 @@
 package com.twitter.algebird
 
-/**
- * Value class to hold references to indices internal to RingBuf.
- */
-case class Idx(value: Int) extends AnyVal {
-  def +(i: Int): Idx = Idx(value + i)
-  def -(i: Int): Idx = Idx(value - i)
-
-  // Look/ itself up in the supplied vector.
-  def of[A](v: Vector[A]): A = v(value)
-
-  // updates the supplied vector with the supplied value.
-  def update[A](v: Vector[A], a: A): Vector[A] = v.updated(value, a)
-}
-
-object Idx {
-  def bounded(i: Long, bound: Int): Idx = Idx(((i + bound) % bound).toInt)
-}
-
-case class RingBuf[A](slots: Vector[A], index: Idx) { lhs =>
+case class RingBuf[A](slots: Vector[A], index: RingBuf.Idx) { lhs =>
   import RingBuf._
   /**
    * Slots are 0-indexed from the current `index`, looking backwards.
@@ -91,6 +73,24 @@ case class RingBuf[A](slots: Vector[A], index: Idx) { lhs =>
 }
 
 object RingBuf {
+  /**
+   * Value class to hold references to indices internal to RingBuf.
+   */
+  case class Idx(value: Int) extends AnyVal {
+    def +(i: Int): Idx = Idx(value + i)
+    def -(i: Int): Idx = Idx(value - i)
+
+    // Looks itself up in the supplied vector.
+    def of[A](v: Vector[A]): A = v(value)
+
+    // updates the supplied vector with the supplied value.
+    def update[A](v: Vector[A], a: A): Vector[A] = v.updated(value, a)
+  }
+
+  object Idx {
+    def bounded(i: Long, bound: Int): Idx = Idx(((i + bound) % bound).toInt)
+  }
+
   def empty[A](size: Int)(implicit ev: Monoid[A]): RingBuf[A] =
     RingBuf(Vector.fill(size)(ev.zero), Idx(0))
 

--- a/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/RingBuf.scala
@@ -1,0 +1,92 @@
+package com.twitter.algebird
+
+case class Idx(value: Int) extends AnyVal {
+  def +(i: Int): Idx = Idx(value + i)
+  def -(i: Int): Idx = Idx(value - i)
+}
+
+object Idx {
+  def bounded(i: Long, bound: Int): Idx = Idx(((i + bound) % bound).toInt)
+}
+
+case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
+  import RingBuf._
+
+  /**
+   * Slots are 0-indexed from the current index, looking backwards.
+   *
+   * `makeIdx` converts an index into a vector position in `slots`.
+   *
+   * i=1, index=5, makeIdx(i)=Idx(4)
+   * i=(slots.size - 1), index=5, makeIdx(i)==Idx(6) (ie last item)
+   */
+  private[this] def makeIdx(i: Long): Idx = Idx.bounded(i, slots.size)
+
+  // TODO - this assertion is a LITTLE janky, since we want to be able
+  // to bump forward during step.
+  private[this] def toInternal(i: Long): Idx = {
+    assert(i >= 0 && i < slots.size, s"$i is out of allowed bounds: [0 $slots.size)")
+    makeIdx(i + index)
+  }
+
+  /**
+   * Returns a copy of the RingBuf with `a` added in to the proper
+   * externally-indexed slot.
+   */
+  def add(a: A, i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
+    val idx = toInternal(i).value
+    copy(slots = slots.updated(idx, ev.plus(slots(idx), a)))
+  }
+
+  /**
+   * Look up the item in the vector by external index.
+   */
+  def apply(i: Long): A = slots(toInternal(i).value)
+
+  /**
+   * Steps the RingBuf forward `i` steps, zero-ing out all new
+   * entries.
+   */
+  def step(i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
+    if (i <= 0) this
+    else {
+      val v = (1L to (i min slots.size)).foldLeft(slots) { (acc, j) =>
+        acc.updated(makeIdx(j + index).value, ev.zero)
+      }
+      RingBuf(v, makeIdx(i + index).value)
+    }
+  }
+
+  def +(rhs: RingBuf[A])(implicit ev: Monoid[A]): RingBuf[A] = {
+    val merge = (lhs.reverseIterator zip rhs.reverseIterator).map {
+      case (l, r) => ev.plus(l, r)
+    }
+    val newSize = lhs.slots.size min rhs.slots.size
+    RingBuf(merge.toVector.reverse, makeIdx(newSize - 1).value)
+  }
+
+  // oldest-to-newest iterator across partial sums
+  def iterator: Iterator[A] =
+    (1 to slots.size).iterator.map(i => slots(makeIdx(index + i).value))
+
+  // newest-to-oldest iterator across partial sums
+  def reverseIterator: Iterator[A] =
+    (0 until slots.size).iterator.map(i => slots(makeIdx(index - i).value))
+
+  def size: Int = slots.size
+  def length: Int = slots.length
+}
+
+object RingBuf {
+  def empty[A](size: Int)(implicit ev: Monoid[A]): RingBuf[A] =
+    RingBuf(Vector.fill(size)(ev.zero), 0)
+
+  def monoid[A](size: Int)(implicit ev: Monoid[A]): Monoid[RingBuf[A]] =
+    Monoid.from(RingBuf.empty(size))(_ + _)
+
+  implicit def equiv[A: Equiv](implicit ev: Equiv[A]): Equiv[RingBuf[A]] =
+    new Equiv[RingBuf[A]] {
+      def equiv(x: RingBuf[A], y: RingBuf[A]): Boolean =
+        (x.iterator zip y.iterator).forall { case (m, n) => ev.equiv(m, n) }
+    }
+}

--- a/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
@@ -36,15 +36,9 @@ case class Windows[A](buf: RingBuf[A], step: Long, time: Long) { lhs =>
   def step(currTime: Long)(implicit ev: Monoid[A]): Windows[A] =
     if (currTime < time + step) this
     else {
-      // we do need to slide forward
+      // slide forward by i (>= 1) time steps
       val i = stepsFrom(time, currTime)
-      require(i >= 1, s"currTime=$currTime, step=$step, time=$time, i=$i")
-
-      // moving forward by i (>= 1) time steps
-      val w = Windows(buf.step(i), step, time + (i * step))
-      require(currTime < w.time + w.step, s"currTime=$currTime, time=$time, w.time=${w.time}")
-      require(currTime >= w.minTime)
-      w
+      Windows(buf.step(i), step, time + (i * step))
     }
 
   /**

--- a/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
@@ -2,6 +2,15 @@ package com.twitter.algebird
 
 import scala.annotation.tailrec
 
+/**
+ * Sam's Notes:
+ *
+ * * Found one bug with +; + was failing with instances of different
+ *   lengths. Fixed with a different, probably inefficient `+`
+ *   implementation... I bet we could make it faster by reversing the
+ *   way we track items in the ring buffer, by advancing backwards?
+ */
+
 //          800 900      700
 //          |   |   1000 |
 // Vector ( 19, 20, 23, 16 )
@@ -17,12 +26,37 @@ import scala.annotation.tailrec
 // 24 hour moving window, with 30 minute resolution (step)
 // (48 + 1 buckets)
 
+/**
+ * case class RingBuf[A](slots: Vector[A], index: Int) {
+ * @inline private[this] def makeIndex(i: Long): Int =
+ * ((i + slots.size) % slots.size).toInt
+ *
+ * private[this] def clear(i: Int)(implicit ev: Monoid[A]): RingBuf[A] =
+ * vect.updated(i, ev.zero)
+ *
+ * def add[A](idx: Int, a: A)(implicit ev: Monoid[A]) = {
+ * val sum = ev.plus(slots(idx), a)
+ * }
+ *
+ * // oldest-to-newest iterator across partial sums
+ * def iterator: Iterator[A] =
+ * (1 to slots.size).iterator.map(i => slots(makeIndex(index + i)))
+ *
+ * // newest-to-oldest iterator across partial sums
+ * def reverseIterator: Iterator[A] =
+ * (0 until slots.size).iterator.map(i => slots(makeIndex(index - i)))
+ * }
+ */
+
 // time range you can support: step * (slots - 1)
 case class Windows[A](slots: Vector[A], index: Int, step: Long, time: Long) { lhs =>
-
   // oldest-to-newest iterator across partial sums
   def iterator: Iterator[A] =
     (1 to slots.size).iterator.map(i => slots(makeIndex(index + i)))
+
+  // newest-to-oldest iterator across partial sums
+  def reverseIterator: Iterator[A] =
+    (0 until slots.size).iterator.map(i => slots(makeIndex(index - i)))
 
   @inline private[this] def makeIndex(i: Long): Int =
     ((i + slots.size) % slots.size).toInt
@@ -30,6 +64,14 @@ case class Windows[A](slots: Vector[A], index: Int, step: Long, time: Long) { lh
   private[this] def clear(vect: Vector[A], i: Int)(implicit ev: Monoid[A]): Vector[A] =
     vect.updated(i, ev.zero)
 
+  /**
+   * We only actually step in increments of `step`. `time` references
+   * the inclusive lower bound of the bucket you're currently in.
+   *
+   * {{{
+   * assert(makeIndex(time % step) == step)
+   * }}}
+   */
   def step(currTime: Long)(implicit ev: Monoid[A]): Windows[A] =
     if (currTime < time + step) {
       // we don't need to slide forward
@@ -55,16 +97,26 @@ case class Windows[A](slots: Vector[A], index: Int, step: Long, time: Long) { lh
       w
     }
 
-  def minTime: Long =
-    time - (slots.size - 1) * step
+  /**
+   * Inclusive lower bound of the supplied slot offset, looking back
+   * from the current slot..
+   */
+  def timeOf(i: Int): Long = time - makeIndex(i) * step
 
+  /**
+   * Step back all the way around the ring buffer.
+   */
+  def minTime: Long = timeOf(slots.size - 1)
+
+  /**
+   * Slots are 0-indexed from the current slot, looking backwards.
+   *
+   * i=4, index=5, vectorIndex=1
+   * i=6, index=5, indexDelta=slots.size - 1 (ie last item)
+   */
   private[this] def slotContains(i: Int, currTime: Long): Boolean = {
-    // i=4, index=5, indexDelta=1
-    // i=6, index=5, indexDelta=slots.size - 1
-    val n = slots.size
-    val indexDelta = ((index - i) + n) % n
-    val start = time - indexDelta * step
-    start <= currTime && currTime < (start + step)
+    val startTime = timeOf(index - i)
+    startTime <= currTime && currTime < (startTime + step)
   }
 
   // invariant: currTime must in [minTime, time + step).
@@ -85,11 +137,8 @@ case class Windows[A](slots: Vector[A], index: Int, step: Long, time: Long) { lh
       copy(slots = slots.updated(i, sum))
     } else step(currTime).add(a, currTime)
 
-  def lowerBoundSum(implicit ev: Monoid[A]): A = {
-    val before = ev.sum(slots.iterator.take(index - 1)) // before
-    val after = ev.sum(slots.iterator.drop(index)) // after
-    ev.plus(before, after)
-  }
+  def lowerBoundSum(implicit ev: Monoid[A]): A =
+    ev.sum(iterator.drop(1))
 
   def upperBoundSum(implicit ev: Monoid[A]): A =
     ev.sum(slots)
@@ -97,27 +146,28 @@ case class Windows[A](slots: Vector[A], index: Int, step: Long, time: Long) { lh
   //   [3,5,6,1]
   // [1,2,4,3]
   //   [5,9,9,1]
+  /**
+   * - Step both forward in time.
+   * - Get an iterator BACK in time from the current index
+   * - `zip` will drop the tail of the longer reverseIterator.
+   * - reverse again before building the new Windows to maintain the
+   *   ring buffer structure, and set the index pointer to the last
+   *   item.
+   */
   def +(rhs: Windows[A])(implicit ev: Monoid[A]): Windows[A] = {
     require(lhs.step == rhs.step)
     val currTime = lhs.time max rhs.time
     val lhs2 = lhs.step(currTime)
     val rhs2 = rhs.step(currTime)
-    val bldr = Vector.newBuilder[A]
-
-    (0 until (lhs2.slots.size min rhs2.slots.size)).foreach { i =>
-      val li = makeIndex(lhs2.index + i)
-      val ri = makeIndex(rhs2.index + i)
-      val lx = lhs2.slots(li)
-      val rx = rhs2.slots(ri)
-      val zx = ev.plus(lx, rx)
-      bldr += zx
+    val newV = (lhs2.reverseIterator zip rhs2.reverseIterator).map {
+      case (l, r) => ev.plus(l, r)
     }
-    Windows(bldr.result(), 0, lhs2.step, currTime)
+    val newEnd = lhs.slots.size min rhs.slots.size
+    Windows(newV.toVector.reverse, makeIndex(newEnd - 1), lhs2.step, currTime)
   }
 }
 
 object Windows {
-
   // step=100ms
   // timeNow=53ms
   // adjustedTime=0ms

--- a/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
@@ -23,135 +23,49 @@ package com.twitter.algebird
 
 // 24 hour moving window, with 30 minute resolution (step)
 // (48 + 1 buckets)
-
-case class Idx(value: Int) extends AnyVal {
-  def +(i: Int): Idx = Idx(value + i)
-  def -(i: Int): Idx = Idx(value - i)
-}
-
-object Idx {
-  def bounded(i: Long, bound: Int): Idx =
-    Idx(((i + bound) % bound).toInt)
-}
-
-object RingBuf {
-  private[RingBuf] def clear[A](v: Vector[A], i: Idx)(implicit ev: Monoid[A]): Vector[A] = v.updated(i.value, ev.zero)
-}
-
-case class RingBuf[+A](slots: Vector[A], index: Int) {
-  import RingBuf._
-
-  /**
-   * Slots are 0-indexed from the current index, looking backwards.
-   *
-   * `makeIndex` converts an index into a vector position in `slots`.
-   *
-   * i=1, index=5, makeIdx(i)=Idx(4)
-   * i=(slots.size - 1), index=5, makeIdx(i)==Idx(6) (ie last item)
-   */
-  private[this] def makeIdx(i: Long): Idx =
-    Idx.bounded(i, slots.size)
-
-  private[this] def internalAdd(idx: Idx, a: A)(implicit ev: Monoid[A]): RingBuf[A] = {
-    val sum = ev.plus(slots(idx.value), a)
-    copy(slots = slots.updated(idx.value, sum))
-  }
-
-  /**
-   * Look up the item in the vector by external index.
-   */
-  def apply(i: Long): A = {
-    assert(i >= 0 && i < slots.size)
-    slots(makeIdx(i + index).value)
-  }
-
-  // oldest-to-newest iterator across partial sums
-  def iterator: Iterator[A] =
-    (1 to slots.size).iterator.map(i => slots(makeIdx(index + i).value))
-
-  // newest-to-oldest iterator across partial sums
-  def reverseIterator: Iterator[A] =
-    (0 until slots.size).iterator.map(i => slots(makeIdx(index - i).value))
-
-  def size: Int = slots.size
-  def length: Int = slots.length
-}
-
+//
 // time range you can support: step * (slots - 1)
+
+/**
+ * We only bump `time` in increments of `step`. `time`
+ * references the inclusive lower bound of the bucket you're currently
+ * in.
+ */
 case class Windows[A](buf: RingBuf[A], step: Long, time: Long) { lhs =>
   /**
-   * TO KILL
+   * Inclusive lower bound of the supplied slot offset, looking back
+   * from the current slot.
    */
-  // TODO kill this, impl detail
-  @inline private[this] def makeIndex(i: Long): Int =
-    ((i + buf.size) % buf.size).toInt
-
-  // This moves up to Ring Buf.
-  private[this] def clear(vect: Vector[A], i: Int)(implicit ev: Monoid[A]): Vector[A] =
-    vect.updated(i, ev.zero)
-
-  // ## Slot/Time Mappings
-
-  // Inclusive lower bound of the supplied slot offset, looking back
-  // from the current slot.
-  private def minTime: Long = timeOf(buf.size - 1)
-
-  @inline private[this] def timeOf(i: Int): Long = time - i * step
+  private def minTime: Long = time - (buf.size - 1) * step
 
   private[this] def stepsFrom(beginning: Long, now: Long): Long =
     ((now - beginning) / step).toLong
 
-  private[this] def slotContains(i: Int, currTime: Long): Boolean =
-    stepsFrom(currTime, time) == i
-
   /**
-   * Remaining Implementation
-   */
-
-  /**
-   * We only actually step in increments of `step`. `time` references
-   * the inclusive lower bound of the bucket you're currently in.
-   *
-   * {{{
-   * assert(makeIndex(time % step) == step)
-   * }}}
+   * Only step forward if nextTime is >= time + step.
    */
   def step(currTime: Long)(implicit ev: Monoid[A]): Windows[A] =
-    if (currTime < time + step) {
-      // we don't need to slide forward
-      this
-    } else {
+    if (currTime < time + step) this
+    else {
       // we do need to slide forward
       val i = stepsFrom(time, currTime)
-      val nextIndex: Int = makeIndex(buf.index + i)
-
       require(i >= 1, s"currTime=$currTime, step=$step, time=$time, i=$i")
 
-      val vect = (1L to (i min buf.size)).foldLeft(buf.slots) { (acc, j) =>
-        clear(acc, makeIndex(buf.index + j))
-      }
-
-      // moving forward by i (>= 2) time steps
-      val w = Windows(RingBuf(vect, nextIndex), step, time + (i * step))
-
+      // moving forward by i (>= 1) time steps
+      val w = Windows(buf.step(i), step, time + (i * step))
       require(currTime < w.time + w.step, s"currTime=$currTime, time=$time, w.time=${w.time}")
       require(currTime >= w.minTime)
       w
     }
 
+  /**
+   * Adding something before minTime is a no-op.
+   */
   def add(a: A, currTime: Long)(implicit ev: Monoid[A]): Windows[A] =
     if (currTime < minTime) this
     else if (currTime < time + step) {
-      val i = stepsFrom(currTime, time)
-      val sum = ev.plus(buf(i), a)
-      copy(buf = buf.copy(slots = buf.slots.updated(makeIndex(i), sum)))
+      copy(buf = buf.add(a, stepsFrom(currTime, time)))
     } else step(currTime).add(a, currTime)
-
-  def lowerBoundSum(implicit ev: Monoid[A]): A =
-    ev.sum(buf.iterator.drop(1))
-
-  def upperBoundSum(implicit ev: Monoid[A]): A =
-    ev.sum(buf.slots)
 
   //   [3,5,6,1]
   // [1,2,4,3]
@@ -167,14 +81,15 @@ case class Windows[A](buf: RingBuf[A], step: Long, time: Long) { lhs =>
   def +(rhs: Windows[A])(implicit ev: Monoid[A]): Windows[A] = {
     require(lhs.step == rhs.step)
     val currTime = lhs.time max rhs.time
-    val lhs2 = lhs.step(currTime)
-    val rhs2 = rhs.step(currTime)
-    val newV = (lhs2.buf.reverseIterator zip rhs2.buf.reverseIterator).map {
-      case (l, r) => ev.plus(l, r)
-    }
-    val newEnd = lhs.buf.slots.size min rhs.buf.slots.size
-    Windows(RingBuf(newV.toVector.reverse, makeIndex(newEnd - 1)), lhs2.step, currTime)
+    val newBuf = lhs.step(currTime).buf + rhs.step(currTime).buf
+    Windows(newBuf, step, currTime)
   }
+
+  def lowerBoundSum(implicit ev: Monoid[A]): A =
+    ev.sum(buf.iterator.drop(1))
+
+  def upperBoundSum(implicit ev: Monoid[A]): A =
+    ev.sum(buf.slots)
 }
 
 object Windows {
@@ -199,4 +114,82 @@ object Windows {
           (x.time == y.time) &&
           (x.buf.iterator zip y.buf.iterator).forall { case (m, n) => ev.equiv(m, n) }
     }
+}
+
+case class Idx(value: Int) extends AnyVal {
+  def +(i: Int): Idx = Idx(value + i)
+  def -(i: Int): Idx = Idx(value - i)
+}
+
+object Idx {
+  def bounded(i: Long, bound: Int): Idx =
+    Idx(((i + bound) % bound).toInt)
+}
+
+case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
+  import RingBuf._
+
+  /**
+   * Slots are 0-indexed from the current index, looking backwards.
+   *
+   * `makeIdx` converts an index into a vector position in `slots`.
+   *
+   * i=1, index=5, makeIdx(i)=Idx(4)
+   * i=(slots.size - 1), index=5, makeIdx(i)==Idx(6) (ie last item)
+   */
+  private[this] def makeIdx(i: Long): Idx = Idx.bounded(i, slots.size)
+
+  // TODO - this assertion is a LITTLE janky, since we want to be able
+  // to bump forward during step.
+  private[this] def toInternal(i: Long): Idx = {
+    assert(i >= 0 && i < slots.size, s"$i is out of allowed bounds: [0 $slots.size)")
+    makeIdx(i + index)
+  }
+
+  /**
+   * Returns a copy of the RingBuf with `a` added in to the proper
+   * externally-indexed slot.
+   */
+  def add(a: A, i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
+    val idx = toInternal(i).value
+    copy(slots = slots.updated(idx, ev.plus(slots(idx), a)))
+  }
+
+  /**
+   * Look up the item in the vector by external index.
+   */
+  def apply(i: Long): A = slots(toInternal(i).value)
+
+  /**
+   * Steps the RingBuf forward `i` steps, zero-ing out all new
+   * entries.
+   */
+  def step(i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
+    if (i <= 0) this
+    else {
+      val v = (1L to (i min slots.size)).foldLeft(slots) { (acc, j) =>
+        acc.updated(makeIdx(j + index).value, ev.zero)
+      }
+      RingBuf(v, makeIdx(i + index).value)
+    }
+  }
+
+  def +(rhs: RingBuf[A])(implicit ev: Monoid[A]): RingBuf[A] = {
+    val merge = (lhs.reverseIterator zip rhs.reverseIterator).map {
+      case (l, r) => ev.plus(l, r)
+    }
+    val newSize = lhs.slots.size min rhs.slots.size
+    RingBuf(merge.toVector.reverse, makeIdx(newSize - 1).value)
+  }
+
+  // oldest-to-newest iterator across partial sums
+  def iterator: Iterator[A] =
+    (1 to slots.size).iterator.map(i => slots(makeIdx(index + i).value))
+
+  // newest-to-oldest iterator across partial sums
+  def reverseIterator: Iterator[A] =
+    (0 until slots.size).iterator.map(i => slots(makeIdx(index - i).value))
+
+  def size: Int = slots.size
+  def length: Int = slots.length
 }

--- a/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
@@ -1,41 +1,30 @@
 package com.twitter.algebird
 
 /**
- * Sam's Notes:
+ *         800 900      700
+ *          |   |   1000 |
+ * Vector ( 19, 20, 23, 16 )
+ *    index=2        ^
+ *    time=1000
+ *    step=100
  *
- * * Found one bug with +; + was failing with instances of different
- *   lengths. Fixed with a different, probably inefficient `+`
- *   implementation... I bet we could make it faster by reversing the
- *   way we track items in the ring buffer, by advancing backwards?
- */
-
-//          800 900      700
-//          |   |   1000 |
-// Vector ( 19, 20, 23, 16 )
-//    index=2        ^
-//    time=1000
-//    step=100
-
-// [700, 800): saw a sum of 16
-// [800, 900): saw a sum of 19
-// [900, 1000): saw a sum of 20
-// [1000, 1100): saw at least a sum of 23 *in progress*
-
-// 24 hour moving window, with 30 minute resolution (step)
-// (48 + 1 buckets)
-//
-// time range you can support: step * (slots - 1)
-
-/**
+ * [700, 800): saw a sum of 16
+ * [800, 900): saw a sum of 19
+ * [900, 1000): saw a sum of 20
+ * [1000, 1100): saw at least a sum of 23 *in progress*
+ *
+ * 24 hour moving window, with 30 minute resolution (step)
+ * (48 + 1 buckets)
+ *
+ * time range you can support: step * (slots - 1)
+ *
  * We only bump `time` in increments of `step`. `time`
  * references the inclusive lower bound of the bucket you're currently
  * in.
  */
 case class Windows[A](buf: RingBuf[A], step: Long, time: Long) { lhs =>
-  /**
-   * Inclusive lower bound of the supplied slot offset, looking back
-   * from the current slot.
-   */
+  // Inclusive lower bound of the supplied slot offset, looking back
+  // from the current slot.
   private def minTime: Long = time - (buf.size - 1) * step
 
   private[this] def stepsFrom(beginning: Long, now: Long): Long =
@@ -85,11 +74,9 @@ case class Windows[A](buf: RingBuf[A], step: Long, time: Long) { lhs =>
     Windows(newBuf, step, currTime)
   }
 
-  def lowerBoundSum(implicit ev: Monoid[A]): A =
-    ev.sum(buf.iterator.drop(1))
+  def lowerBoundSum(implicit ev: Monoid[A]): A = ev.sum(buf.iterator.drop(1))
 
-  def upperBoundSum(implicit ev: Monoid[A]): A =
-    ev.sum(buf.slots)
+  def upperBoundSum(implicit ev: Monoid[A]): A = ev.sum(buf.slots)
 }
 
 object Windows {

--- a/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
+++ b/algebird-core/src/main/scala/com/twitter/algebird/Windows.scala
@@ -96,100 +96,17 @@ object Windows {
   // step=100ms
   // timeNow=53ms
   // adjustedTime=0ms
-  def empty[A](timeStep: Int, numSteps: Int)(implicit ev: Monoid[A]): Windows[A] =
-    Windows(RingBuf(Vector.fill(numSteps + 1)(ev.zero), 0), timeStep, 0L)
+  def empty[A: Monoid](timeStep: Int, numSteps: Int): Windows[A] =
+    Windows(RingBuf.empty[A](numSteps + 1), timeStep, 0L)
 
   def monoid[A](timeStep: Int, numSteps: Int)(implicit ev: Monoid[A]): Monoid[Windows[A]] =
-    new Monoid[Windows[A]] {
-      def zero: Windows[A] =
-        Windows.empty(timeStep, numSteps)
-      def plus(x: Windows[A], y: Windows[A]): Windows[A] =
-        x + y
-    }
+    Monoid.from(Windows.empty(timeStep, numSteps))(_ + _)
 
-  implicit def equiv[A](implicit ev: Equiv[A]): Equiv[Windows[A]] =
+  implicit def equiv[A: Equiv]: Equiv[Windows[A]] =
     new Equiv[Windows[A]] {
       def equiv(x: Windows[A], y: Windows[A]): Boolean =
         (x.step == y.step) &&
           (x.time == y.time) &&
-          (x.buf.iterator zip y.buf.iterator).forall { case (m, n) => ev.equiv(m, n) }
+          Equiv[RingBuf[A]].equiv(x.buf, y.buf)
     }
-}
-
-case class Idx(value: Int) extends AnyVal {
-  def +(i: Int): Idx = Idx(value + i)
-  def -(i: Int): Idx = Idx(value - i)
-}
-
-object Idx {
-  def bounded(i: Long, bound: Int): Idx =
-    Idx(((i + bound) % bound).toInt)
-}
-
-case class RingBuf[A](slots: Vector[A], index: Int) { lhs =>
-  import RingBuf._
-
-  /**
-   * Slots are 0-indexed from the current index, looking backwards.
-   *
-   * `makeIdx` converts an index into a vector position in `slots`.
-   *
-   * i=1, index=5, makeIdx(i)=Idx(4)
-   * i=(slots.size - 1), index=5, makeIdx(i)==Idx(6) (ie last item)
-   */
-  private[this] def makeIdx(i: Long): Idx = Idx.bounded(i, slots.size)
-
-  // TODO - this assertion is a LITTLE janky, since we want to be able
-  // to bump forward during step.
-  private[this] def toInternal(i: Long): Idx = {
-    assert(i >= 0 && i < slots.size, s"$i is out of allowed bounds: [0 $slots.size)")
-    makeIdx(i + index)
-  }
-
-  /**
-   * Returns a copy of the RingBuf with `a` added in to the proper
-   * externally-indexed slot.
-   */
-  def add(a: A, i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
-    val idx = toInternal(i).value
-    copy(slots = slots.updated(idx, ev.plus(slots(idx), a)))
-  }
-
-  /**
-   * Look up the item in the vector by external index.
-   */
-  def apply(i: Long): A = slots(toInternal(i).value)
-
-  /**
-   * Steps the RingBuf forward `i` steps, zero-ing out all new
-   * entries.
-   */
-  def step(i: Long)(implicit ev: Monoid[A]): RingBuf[A] = {
-    if (i <= 0) this
-    else {
-      val v = (1L to (i min slots.size)).foldLeft(slots) { (acc, j) =>
-        acc.updated(makeIdx(j + index).value, ev.zero)
-      }
-      RingBuf(v, makeIdx(i + index).value)
-    }
-  }
-
-  def +(rhs: RingBuf[A])(implicit ev: Monoid[A]): RingBuf[A] = {
-    val merge = (lhs.reverseIterator zip rhs.reverseIterator).map {
-      case (l, r) => ev.plus(l, r)
-    }
-    val newSize = lhs.slots.size min rhs.slots.size
-    RingBuf(merge.toVector.reverse, makeIdx(newSize - 1).value)
-  }
-
-  // oldest-to-newest iterator across partial sums
-  def iterator: Iterator[A] =
-    (1 to slots.size).iterator.map(i => slots(makeIdx(index + i).value))
-
-  // newest-to-oldest iterator across partial sums
-  def reverseIterator: Iterator[A] =
-    (0 until slots.size).iterator.map(i => slots(makeIdx(index - i).value))
-
-  def size: Int = slots.size
-  def length: Int = slots.length
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/RingBufLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/RingBufLaws.scala
@@ -1,0 +1,12 @@
+package com.twitter.algebird
+
+import org.scalatest.{ PropSpec, Matchers }
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.Checkers.check
+import org.scalacheck.{ Gen, Arbitrary }
+import Arbitrary.arbitrary
+
+// Shell for RingBuf laws.
+class RingBufLaws extends PropSpec with PropertyChecks with Matchers {
+  import BaseProperties._
+}

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowsLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowsLaws.scala
@@ -21,7 +21,7 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
       vect <- Gen.buildableOfN[Vector[A], A](w.totalSize, arbitrary[A])
       n <- arbitrary[Short].map(_ & 0xffff)
       i <- arbitrary[Short].map(i => (i & 0xffff) % w.totalSize)
-    } yield Windows(RingBuf(vect, Idx(i)), w.step, (n * w.totalSize + i) * w.step))
+    } yield Windows(RingBuf(vect, RingBuf.Idx(i)), w.step, (n * w.totalSize + i) * w.step))
 
   def runProperties[A: Arbitrary: Equiv: Monoid](implicit w: WindowsParams): Unit =
     check(monoidLawsEquiv[Windows[A]])

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowsLaws.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowsLaws.scala
@@ -21,7 +21,7 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
       vect <- Gen.buildableOfN[Vector[A], A](w.totalSize, arbitrary[A])
       n <- arbitrary[Short].map(_ & 0xffff)
       i <- arbitrary[Short].map(i => (i & 0xffff) % w.totalSize)
-    } yield Windows(RingBuf(vect, i), w.step, (n * w.totalSize + i) * w.step))
+    } yield Windows(RingBuf(vect, Idx(i)), w.step, (n * w.totalSize + i) * w.step))
 
   def runProperties[A: Arbitrary: Equiv: Monoid](implicit w: WindowsParams): Unit =
     check(monoidLawsEquiv[Windows[A]])

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
@@ -7,7 +7,6 @@ import org.scalacheck.{ Gen, Arbitrary }
 import Arbitrary.arbitrary
 
 class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
-
   import BaseProperties._
 
   case class WindowsParams(step: Int, numSteps: Int) {
@@ -27,22 +26,6 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
   def runProperties[A: Arbitrary: Equiv: Monoid](implicit w: WindowsParams): Unit =
     check(monoidLawsEquiv[Windows[A]])
 
-  // property("failing case") {
-  //   implicit val w = WindowsParams(100, 10)
-  //   val m = windowsMonoid[Int]
-  //
-  //   //val arg0 = Windows(Vector(1032478800, -1, 1, -1830505412, 598145662, -2147483648, -1525890587, -1764787492, 863764197, 1490172142, 427417516),0,100,0)
-  //
-  //   //val arg0 = Windows(Vector(2147483647, 1404594962, -1181511465, 1902416464, 1, 1, -886569095, 1, 0, -809395231, -763138612),1,100,59973200)
-  //
-  //   val arg0 = Windows(Vector(-731477864, -271003139, 1, 227212362, 1735155773, -2147483648, 1496978553, -95735355, 2147483647, -1957555367, -1460422666),5,100,425100)
-  //
-  //   val sum = (m.zero + arg0)
-  //   println((arg0.step, arg0.time, arg0.iterator.toList))
-  //   println((sum.step, sum.time, sum.iterator.toList))
-  //   Equiv[Windows[Int]].equiv(sum, arg0) shouldBe true
-  // }
-
   property("test Monoid[Windows[Int]] #1") {
     implicit val w = WindowsParams(100, 10)
     runProperties[Int]
@@ -60,45 +43,23 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
     Equiv[Windows[Int]].equiv(l + r, l2 + r) shouldBe true
   }
 
-  // [info]       arg0 = (-238125844828599004,0), // 2 shrinks
-  // [info]       arg1 = Vector((-1327071966132228755,0)) // 3 shrinks
-  // property("works correctly") {
-  //   forAll { (e0: (Long, Int), events0: Vector[(Long, Int)]) =>
-  //     val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted
-  //     val t0 = events.head._1
-  //     val lastT = events.last._1
-  //     val span = lastT - t0
+  property("works correctly") {
+    forAll { (e0: (Long, Int), events0: Vector[(Long, Int)]) =>
+      val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted
+      val t0 = events.head._1
+      val lastT = events.last._1
+      val span = lastT - t0
 
-  //     val StepSize = ((span / 100) max 1).toInt
-  //     val NumSteps = 20
-  //     val WindowSize = NumSteps * StepSize
+      val StepSize = (((span / 100) max 1) min 1000000).toInt
+      val NumSteps = 20
+      val WindowSize = NumSteps * StepSize
 
-  //     val empty: Windows[Int] = Windows.empty[Int](StepSize, NumSteps)
-  //     val windows = events.foldLeft(empty) { case (w, (t, x)) => w.add(x, t) }
-  //     val realSum = events.iterator.collect { case (t, x) if t > lastT - WindowSize => x }.sum
+      val empty: Windows[Int] = Windows.empty[Int](StepSize, NumSteps)
+      val windows = events.foldLeft(empty) { case (w, (t, x)) => w.add(x, t) }
+      val realSum = events.iterator.collect { case (t, x) if t > lastT - WindowSize => x }.sum
 
-  //     windows.lowerBoundSum should be <= realSum
-  //     windows.upperBoundSum should be >= realSum
-  //   }
-  // }
-
-  def testCase(e0: (Long, Int), events0: Vector[(Long, Int)]): Unit = {
-    val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted
-    val t0 = events.head._1
-    val lastT = events.last._1
-    val span = lastT - t0
-
-    val StepSize = (((span / 100) max 1) min 1000000).toInt
-    val NumSteps = 20
-    val WindowSize = NumSteps * StepSize
-
-    val empty: Windows[Int] = Windows.empty[Int](StepSize, NumSteps)
-    val windows = events.foldLeft(empty) { case (w, (t, x)) => w.add(x, t) }
-    val realSum = events.iterator.collect { case (t, x) if t > lastT - WindowSize => x }.sum
-
-    windows.lowerBoundSum should be <= realSum
-    windows.upperBoundSum should be >= realSum
+      windows.lowerBoundSum should be <= realSum
+      windows.upperBoundSum should be >= realSum
+    }
   }
-
-  testCase((0L, 0), Vector((9223372036854775807L, 0)))
 }

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
@@ -22,7 +22,7 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
       vect <- Gen.buildableOfN[Vector[A], A](w.totalSize, arbitrary[A])
       n <- arbitrary[Short].map(_ & 0xffff)
       i <- arbitrary[Short].map(i => (i & 0xffff) % w.totalSize)
-    } yield Windows(vect, i, w.step, (n * w.totalSize + i) * w.step))
+    } yield Windows(RingBuf(vect, i), w.step, (n * w.totalSize + i) * w.step))
 
   def runProperties[A: Arbitrary: Equiv: Monoid](implicit w: WindowsParams): Unit =
     check(monoidLawsEquiv[Windows[A]])

--- a/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
+++ b/algebird-test/src/test/scala/com/twitter/algebird/WindowsTest.scala
@@ -30,13 +30,13 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
   // property("failing case") {
   //   implicit val w = WindowsParams(100, 10)
   //   val m = windowsMonoid[Int]
-  // 
+  //
   //   //val arg0 = Windows(Vector(1032478800, -1, 1, -1830505412, 598145662, -2147483648, -1525890587, -1764787492, 863764197, 1490172142, 427417516),0,100,0)
-  // 
+  //
   //   //val arg0 = Windows(Vector(2147483647, 1404594962, -1181511465, 1902416464, 1, 1, -886569095, 1, 0, -809395231, -763138612),1,100,59973200)
-  // 
+  //
   //   val arg0 = Windows(Vector(-731477864, -271003139, 1, 227212362, 1735155773, -2147483648, 1496978553, -95735355, 2147483647, -1957555367, -1460422666),5,100,425100)
-  // 
+  //
   //   val sum = (m.zero + arg0)
   //   println((arg0.step, arg0.time, arg0.iterator.toList))
   //   println((sum.step, sum.time, sum.iterator.toList))
@@ -53,25 +53,34 @@ class WindowsLaws extends PropSpec with PropertyChecks with Matchers {
     runProperties[BigInt]
   }
 
-  property("works correctly") {
-    forAll { (e0: (Long, Int), events0: Vector[(Long, Int)]) =>
-      val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted
-      val t0 = events.head._1
-      val lastT = events.last._1
-      val span = lastT - t0
-
-      val StepSize = ((span / 100) max 1).toInt
-      val NumSteps = 20
-      val WindowSize = NumSteps * StepSize
-
-      val empty: Windows[Int] = Windows.empty[Int](StepSize, NumSteps)
-      val windows = events.foldLeft(empty) { case (w, (t, x)) => w.add(x, t) }
-      val realSum = events.iterator.collect { case (t, x) if t > lastT - WindowSize => x }.sum
-
-      windows.lowerBoundSum should be <= realSum
-      windows.upperBoundSum should be >= realSum
-    }
+  property("Windows of different sizes should add") {
+    val l = Windows.empty[Int](100, 10).add(13, 95).add(12, 103).add(3, 105)
+    val l2 = Windows.empty[Int](100, 5).add(13, 95).add(12, 103).add(3, 105)
+    val r = Windows.empty[Int](100, 5).add(2, 95)
+    Equiv[Windows[Int]].equiv(l + r, l2 + r) shouldBe true
   }
+
+  // [info]       arg0 = (-238125844828599004,0), // 2 shrinks
+  // [info]       arg1 = Vector((-1327071966132228755,0)) // 3 shrinks
+  // property("works correctly") {
+  //   forAll { (e0: (Long, Int), events0: Vector[(Long, Int)]) =>
+  //     val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted
+  //     val t0 = events.head._1
+  //     val lastT = events.last._1
+  //     val span = lastT - t0
+
+  //     val StepSize = ((span / 100) max 1).toInt
+  //     val NumSteps = 20
+  //     val WindowSize = NumSteps * StepSize
+
+  //     val empty: Windows[Int] = Windows.empty[Int](StepSize, NumSteps)
+  //     val windows = events.foldLeft(empty) { case (w, (t, x)) => w.add(x, t) }
+  //     val realSum = events.iterator.collect { case (t, x) if t > lastT - WindowSize => x }.sum
+
+  //     windows.lowerBoundSum should be <= realSum
+  //     windows.upperBoundSum should be >= realSum
+  //   }
+  // }
 
   def testCase(e0: (Long, Int), events0: Vector[(Long, Int)]): Unit = {
     val events = (e0 +: events0).map { case (t0, x) => (t0 & 0x7fffffffffffL, x) }.sorted


### PR DESCRIPTION
The tests are passing now! The issue, as I think you found, was an overflow with the window size - copying your line up from the single test below fixed everything up.

I also pulled out the ring buffer operations into their own case class, which I THINK makes the `Windows` implementation easier to read and understand.

We may want to nuke the goofy `Idx` value class that I added - I wanted the compiler's help in distinguishing between the indexing that the user passed in and the internal indexing into the vector captured by the ring buffer.
